### PR TITLE
feat: Implement Cache Detector plugin v0.1

### DIFF
--- a/assets/cache-detector-admin-bar.css
+++ b/assets/cache-detector-admin-bar.css
@@ -1,0 +1,47 @@
+/* Cache Detector Admin Bar Styles */
+#wpadminbar #wp-admin-bar-cache_detector_status .ab-item {
+    text-decoration: none;
+}
+
+.cache-detector-status-text {
+    padding: 0 5px;
+    border-radius: 3px;
+    font-weight: bold;
+    text-shadow: none;
+}
+
+.cache-status-hit {
+    background-color: #4CAF50; /* Green */
+    color: white;
+}
+
+.cache-status-miss {
+    background-color: #f44336; /* Red */
+    color: white;
+}
+
+.cache-status-bypass {
+    background-color: #ff9800; /* Orange */
+    color: white;
+}
+
+.cache-status-dynamic {
+    background-color: #2196F3; /* Blue */
+    color: white;
+}
+
+.cache-status-uncached {
+    background-color: #757575; /* Grey */
+    color: white;
+}
+
+.cache-status-unknown {
+    background-color: #9E9E9E; /* Grey */
+    color: white;
+}
+
+/* Style for the icon */
+#wpadminbar #wp-admin-bar-cache_detector_status .ab-icon::before {
+    content: "\f110"; /* dashicons-performance */
+    top: 3px;
+}

--- a/assets/cache-detector-assets.js
+++ b/assets/cache-detector-assets.js
@@ -1,0 +1,143 @@
+// Cache Detector Assets - JavaScript
+(function() {
+    'use strict';
+
+    window.addEventListener('load', function() {
+        if (typeof performance === 'undefined' || typeof performance.getEntriesByType === 'undefined') {
+            console.warn('[Cache Detector] Performance API not supported.');
+            return;
+        }
+
+        // Ensure this runs only for admins who can see the admin bar (implicit capability check)
+        // And only if our localized data is present
+        if (typeof cache_detector_ajax === 'undefined' || !cache_detector_ajax.nonce) {
+            // console.log('[Cache Detector] AJAX data not available for asset script.');
+            return;
+        }
+
+        const resources = performance.getEntriesByType('resource');
+        const assetData = [];
+
+        resources.forEach(function(resource) {
+            let status = 'UNKNOWN';
+            let detectedBy = 'PerformanceAPI';
+            let transferSize = resource.transferSize;
+            let decodedBodySize = resource.decodedBodySize;
+            let serverTiming = [];
+
+            if (resource.serverTiming) {
+                resource.serverTiming.forEach(function(timing) {
+                    serverTiming.push({
+                        name: timing.name,
+                        duration: timing.duration,
+                        description: timing.description
+                    });
+                });
+            }
+
+            // Check for ServiceWorker involvement first
+            if (resource.deliveryType === 'servicebuffer') { // This is a custom property some SWs might set, not standard
+                status = 'HIT (ServiceWorker)'; // Example, actual detection is more complex
+                detectedBy = 'ServiceWorker Heuristic';
+            } else if (transferSize === 0 && decodedBodySize > 0) {
+                // If transferSize is 0 and it's not an empty file, it's likely from memory/disk cache (browser)
+                status = 'HIT (Browser Cache - Memory/Disk)';
+                detectedBy = 'PerformanceAPI (transferSize=0)';
+            } else if (transferSize > 0 && transferSize < decodedBodySize) {
+                // If transferSize is small but not 0, it could be a 304 Not Modified
+                // This is a heuristic. A small file could also just be small.
+                // True 304s often have transferSize representing only header size.
+                // Let's assume for now if it's significantly smaller.
+                // A more robust check would be to see if encodedBodySize is 0 and transferSize > 0
+                 if (resource.encodedBodySize === 0 && transferSize > 0) {
+                    status = 'HIT (Browser Cache - 304 Not Modified)';
+                    detectedBy = 'PerformanceAPI (encodedBodySize=0, transferSize>0)';
+                } else {
+                    // Could be a small file, or partial content, or just compressed well
+                    status = 'DOWNLOADED_OR_PARTIAL';
+                }
+            } else if (transferSize >= decodedBodySize && decodedBodySize > 0) {
+                status = 'DOWNLOADED'; // Likely fetched from the network
+                detectedBy = 'PerformanceAPI (transferSize >= decodedBodySize)';
+            } else if (decodedBodySize === 0 && transferSize > 0){
+                // Example: a redirect that isn't followed by the performance entry, or a HEAD response.
+                status = 'INFO (No Body)';
+            }
+
+
+            // Attempt to interpret server-timing headers if available
+            // This is highly dependent on server/CDN configuration
+            if (serverTiming.length > 0) {
+                let cdnHit = false;
+                let cfCacheStatus = null;
+                let otherServerTimingInfo = [];
+
+                serverTiming.forEach(function(st) {
+                    if (st.name === 'cdn-cache' && st.description === 'HIT') {
+                        cdnHit = true;
+                    }
+                    if (st.name === 'cf-cache-status') { // Cloudflare specific via Server-Timing
+                        cfCacheStatus = st.description;
+                    }
+                    // Akamai: Server-Timing: cdn-cache; desc=HIT
+                    // Fastly: Server-Timing: fastly_cache; desc=HIT
+                    // Generic: server-timing: cache;desc=hit
+                    if ((st.name.includes('cdn') || st.name.includes('cache')) && st.description.toUpperCase() === 'HIT') {
+                        cdnHit = true;
+                    }
+                    otherServerTimingInfo.push(st.name + ':' + st.description);
+                });
+
+                if (cfCacheStatus) {
+                    status = cfCacheStatus.toUpperCase() + ' (Cloudflare)';
+                    detectedBy = 'ServerTiming (cf-cache-status)';
+                } else if (cdnHit) {
+                    status = 'HIT (CDN)';
+                    detectedBy = 'ServerTiming (cdn-cache)';
+                } else if (otherServerTimingInfo.length > 0 && status === 'DOWNLOADED') {
+                    // If downloaded, but server timing has info, it might be a MISS from CDN
+                    status = 'MISS_OR_DYNAMIC (CDN)';
+                    detectedBy = 'ServerTiming ('+ otherServerTimingInfo.join(', ') +')';
+                }
+            }
+
+
+            assetData.push({
+                url: resource.name,
+                status: status,
+                transferSize: transferSize,
+                decodedBodySize: decodedBodySize,
+                initiatorType: resource.initiatorType,
+                detectedBy: detectedBy,
+                serverTiming: serverTiming // Send for more detailed analysis later
+            });
+        });
+
+        if (assetData.length > 0) {
+            // Send data to backend via AJAX
+            const xhr = new XMLHttpRequest();
+            xhr.open('POST', cache_detector_ajax.ajax_url, true);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            xhr.onload = function() {
+                if (xhr.status >= 200 && xhr.status < 400) {
+                    // console.log('[Cache Detector] Asset data sent:', xhr.responseText);
+                    // Potentially trigger an event or update admin bar here if needed immediately
+                } else {
+                    console.error('[Cache Detector] Error sending asset data:', xhr.status, xhr.statusText);
+                }
+            };
+            xhr.onerror = function() {
+                console.error('[Cache Detector] Network error sending asset data.');
+            };
+
+            const params = new URLSearchParams();
+            params.append('action', 'cache_detector_receive_assets');
+            params.append('nonce', cache_detector_ajax.nonce);
+            params.append('asset_data', JSON.stringify(assetData));
+            params.append('page_url', window.location.href);
+
+
+            xhr.send(params.toString());
+        }
+    });
+})();

--- a/cache-detector.php
+++ b/cache-detector.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Plugin Name:       Cache Detector
+ * Plugin URI:        https://example.com/plugins/cache-detector/
+ * Description:       Detects and displays cache status for loaded URLs in WordPress.
+ * Version:           0.1.0
+ * Author:            Jules AI Assistant
+ * Author URI:        https://example.com/
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       cache-detector
+ * Domain Path:       /languages
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+define( 'CACHE_DETECTOR_VERSION', '0.1.0' );
+define( 'CACHE_DETECTOR_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'CACHE_DETECTOR_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// Main plugin class
+class Cache_Detector {
+
+    private static $instance;
+    private $main_request_cache_status = 'UNKNOWN by Cache Detector (Initializing)';
+    private $main_request_headers = array();
+
+    public static function get_instance() {
+        if ( ! isset( self::$instance ) ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'plugins_loaded', array( $this, 'init' ) );
+        register_activation_hook( __FILE__, array( $this, 'activate' ) );
+        register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
+    }
+
+    public function init() {
+        if ( defined('WP_DEBUG') && WP_DEBUG ) {
+            error_log('[Cache Detector] Plugin initialized.');
+        }
+
+        if( !is_admin() ) {
+            add_action( 'send_headers', array( $this, 'inspect_main_request_headers' ), 9 );
+            add_action( 'template_redirect', array( $this, 'start_html_inspection_buffer' ), 0 );
+        }
+
+        add_action( 'admin_bar_menu', array( $this, 'add_admin_bar_menu' ), 999 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+
+        add_action( 'wp_ajax_cache_detector_receive_assets', array( $this, 'handle_receive_assets_ajax' ) );
+    }
+
+    public function handle_receive_assets_ajax() {
+        check_ajax_referer( 'cache_detector_asset_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Permission denied.', 403 );
+            return;
+        }
+
+        $asset_data_json = isset( $_POST['asset_data'] ) ? stripslashes( $_POST['asset_data'] ) : '';
+        $page_url = isset( $_POST['page_url'] ) ? esc_url_raw( $_POST['page_url'] ) : '';
+
+        if ( empty( $asset_data_json ) || empty( $page_url ) ) {
+            wp_send_json_error( 'Missing data.', 400 );
+            return;
+        }
+
+        $asset_data = json_decode( $asset_data_json, true );
+
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            wp_send_json_error( 'Invalid JSON data: ' . json_last_error_msg(), 400 );
+            return;
+        }
+
+        $sanitized_asset_data = array();
+        if (is_array($asset_data)) {
+            foreach ($asset_data as $item) {
+                $sanitized_item = array(
+                    'url'             => isset($item['url']) ? esc_url_raw($item['url']) : '',
+                    'status'          => isset($item['status']) ? sanitize_text_field($item['status']) : 'UNKNOWN',
+                    'transferSize'    => isset($item['transferSize']) ? intval($item['transferSize']) : 0,
+                    'decodedBodySize' => isset($item['decodedBodySize']) ? intval($item['decodedBodySize']) : 0,
+                    'initiatorType'   => isset($item['initiatorType']) ? sanitize_text_field($item['initiatorType']) : '',
+                    'detectedBy'      => isset($item['detectedBy']) ? sanitize_text_field($item['detectedBy']) : '',
+                    'serverTiming'    => array(), // Initialize
+                );
+                // Sanitize serverTiming if it exists and is an array
+                if (isset($item['serverTiming']) && is_array($item['serverTiming'])) {
+                    foreach ($item['serverTiming'] as $st_entry) {
+                        if (is_array($st_entry) && isset($st_entry['name'])) { // Assuming it's an array of objects
+                             $sanitized_item['serverTiming'][] = sanitize_text_field($st_entry['name'] . ': ' . (isset($st_entry['description']) ? $st_entry['description'] : (isset($st_entry['duration']) ? $st_entry['duration'] : '')));
+                        } elseif (is_string($st_entry)) { // Fallback if it's already a string
+                            $sanitized_item['serverTiming'][] = sanitize_text_field($st_entry);
+                        }
+                    }
+                }
+
+                if (!empty($sanitized_item['url'])) {
+                    $sanitized_asset_data[] = $sanitized_item;
+                }
+            }
+        }
+
+        if (empty($sanitized_asset_data)) {
+            wp_send_json_error( 'No valid asset data provided after sanitization.', 400 );
+            return;
+        }
+
+        $user_id = get_current_user_id();
+        $transient_key = 'cd_assets_' . md5( $page_url . '_' . $user_id );
+        set_transient( $transient_key, $sanitized_asset_data, 5 * MINUTE_IN_SECONDS );
+
+        if ( defined('WP_DEBUG') && WP_DEBUG ) {
+            error_log('[Cache Detector] AJAX Handler: Received and stored asset data for URL: ' . $page_url . '. Transient key: ' . $transient_key . '. Count: ' . count($sanitized_asset_data));
+        }
+
+        wp_send_json_success( array( 'message' => 'Asset data received.', 'count' => count( $sanitized_asset_data ) ) );
+    }
+
+    public function enqueue_frontend_assets() {
+        if ( is_admin_bar_showing() && current_user_can('manage_options') && !is_admin() ) {
+            wp_enqueue_style(
+                'cache-detector-admin-bar',
+                CACHE_DETECTOR_PLUGIN_URL . 'assets/cache-detector-admin-bar.css',
+                array(),
+                CACHE_DETECTOR_VERSION
+            );
+
+            wp_enqueue_script(
+                'cache-detector-assets',
+                CACHE_DETECTOR_PLUGIN_URL . 'assets/cache-detector-assets.js',
+                array(),
+                CACHE_DETECTOR_VERSION,
+                true
+            );
+
+            wp_localize_script(
+                'cache-detector-assets',
+                'cache_detector_ajax',
+                array(
+                    'ajax_url' => admin_url( 'admin-ajax.php' ),
+                    'nonce'    => wp_create_nonce( 'cache_detector_asset_nonce' ),
+                )
+            );
+        }
+    }
+
+    public function enqueue_admin_assets() {
+        if ( is_admin_bar_showing() && current_user_can('manage_options') ) {
+             wp_enqueue_style(
+                'cache-detector-admin-bar',
+                CACHE_DETECTOR_PLUGIN_URL . 'assets/cache-detector-admin-bar.css',
+                array(),
+                CACHE_DETECTOR_VERSION
+            );
+        }
+    }
+
+    public function add_admin_bar_menu( $wp_admin_bar ) {
+        if ( ! current_user_can('manage_options') ) return;
+
+        // On admin pages (except AJAX), header/HTML inspection doesn't run for main content,
+        // so status would be the initial value or from a previous frontend load if we stored it more globally.
+        // For now, it shows the current state of $this->main_request_cache_status.
+        $status_output = $this->main_request_cache_status;
+
+        $status_class = 'cache-status-unknown';
+        if (strpos($status_output, 'HIT') === 0) $status_class = 'cache-status-hit';
+        elseif (strpos($status_output, 'MISS') === 0) $status_class = 'cache-status-miss';
+        elseif (strpos($status_output, 'BYPASS') === 0) $status_class = 'cache-status-bypass';
+        elseif (strpos($status_output, 'DYNAMIC') === 0) $status_class = 'cache-status-dynamic';
+        elseif (strpos($status_output, 'UNCACHED') === 0) $status_class = 'cache-status-uncached';
+        elseif (strpos($status_output, 'INFO') === 0) $status_class = 'cache-status-dynamic'; // Treat INFO as dynamic for color
+
+        $wp_admin_bar->add_node( array(
+            'id'    => 'cache_detector_status',
+            'title' => '<span class="ab-icon dashicons-performance"></span><span class="cache-detector-status-text ' . esc_attr($status_class) . '">Cache: ' . esc_html( $status_output ) . '</span>',
+            'href'  => '#',
+            'meta'  => array( 'class' => 'cache-detector-admin-bar-node', 'title' => 'Main Page Cache Status by Cache Detector' ),
+        ) );
+
+        $headers_string = '';
+        if (!empty($this->main_request_headers) && is_array($this->main_request_headers)) {
+            foreach($this->main_request_headers as $header) $headers_string .= esc_html($header) . "\n";
+        } else {
+            $headers_string = 'No headers captured for this view (or not on frontend).';
+        }
+
+        $wp_admin_bar->add_node( array(
+            'id'     => 'cache_detector_headers_raw',
+            'parent' => 'cache_detector_status',
+            'title'  => 'View Raw Page Headers',
+            'href'   => '#',
+            'meta'   => array( 'onclick' => 'alert("Collected Headers For Main Page:\n\n' . esc_js($headers_string) . '"); return false;', 'title' => 'Click to view raw response headers for the main page.' )
+        ));
+
+        if (is_admin()) return; // Asset display is only for frontend.
+
+        $user_id = get_current_user_id();
+        $current_page_url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+        $transient_key = 'cd_assets_' . md5( $current_page_url . '_' . $user_id );
+        $assets = get_transient( $transient_key );
+
+        if ( $assets && is_array( $assets ) ) {
+            $wp_admin_bar->add_node( array( 'id' => 'cache_detector_assets_title', 'parent' => 'cache_detector_status', 'title' => '--- Loaded Assets (Max 20) ---', 'href' => false, 'meta'  => array('class' => 'cache-detector-asset-title') ) );
+            $count = 0;
+            foreach ( $assets as $index => $asset ) {
+                if ($count++ >= 20) {
+                    $wp_admin_bar->add_node( array( 'id' => 'cache_detector_asset_limit', 'parent' => 'cache_detector_status', 'title' => '...more assets loaded (display limited)', 'href' => '#') );
+                    break;
+                }
+                $asset_status_class = 'cache-status-unknown';
+                if (strpos($asset['status'], 'HIT') === 0) $asset_status_class = 'cache-status-hit';
+                elseif (strpos($asset['status'], 'MISS') === 0 || strpos($asset['status'], 'DOWNLOADED') === 0 || strpos($asset['status'], 'DYNAMIC') === 0) $asset_status_class = 'cache-status-miss'; // Treat downloaded/dynamic as MISS for assets
+                elseif (strpos($asset['status'], 'BYPASS') === 0) $asset_status_class = 'cache-status-bypass';
+                elseif (strpos($asset['status'], 'UNCACHED') === 0) $asset_status_class = 'cache-status-uncached';
+
+                $asset_url_display = basename( $asset['url'] );
+                if (strlen($asset_url_display) > 45) $asset_url_display = '...' . substr($asset_url_display, -42);
+                $title = '<span class="' . esc_attr($asset_status_class) . '" style="display: inline-block; padding: 0px 2px; border-radius: 2px; margin-right: 3px; font-size:0.9em;">' . esc_html( strtoupper(explode(' ', $asset['status'])[0]) ) . '</span> ' . esc_html( $asset_url_display );
+
+                $full_details = "URL: " . esc_js($asset['url']) . "\n";
+                $full_details .= "Status: " . esc_js($asset['status']) . "\n";
+                $full_details .= "Detected By: " . esc_js($asset['detectedBy']) . "\n";
+                $full_details .= "Transfer Size: " . esc_js($asset['transferSize']) . " B\n";
+                $full_details .= "Decoded Size: " . esc_js($asset['decodedBodySize']) . " B\n";
+                $full_details .= "Initiator: " . esc_js($asset['initiatorType']);
+                if (!empty($asset['serverTiming']) && is_array($asset['serverTiming'])) {
+                    $full_details .= "\nServer Timing: \n";
+                    foreach($asset['serverTiming'] as $st) $full_details .= " - " . esc_js($st) . "\n";
+                }
+                $wp_admin_bar->add_node( array( 'id' => 'cache_detector_asset_' . $index, 'parent' => 'cache_detector_status', 'title' => $title, 'href' => '#', 'meta' => array( 'title' => esc_attr($asset['url']) . ' | Status: ' . esc_attr($asset['status']), 'onclick' => 'alert("Asset Details:\n\n' . $full_details . '"); return false;' ) ) );
+            }
+        } else {
+            if ( defined('WP_DEBUG') && WP_DEBUG && !is_admin() ) error_log('[Cache Detector] Admin Bar: No asset data in transient ' . $transient_key);
+        }
+    }
+
+    public function start_html_inspection_buffer() {
+        if ( is_admin() || wp_doing_ajax() || !current_user_can('manage_options') || headers_sent() ) {
+            return;
+        }
+        ob_start(array($this, 'inspect_html_footprints'));
+    }
+
+    public function inspect_html_footprints( $buffer ) {
+        if ( empty($buffer) || !is_string($buffer) ) return $buffer;
+
+        $html_status_text = 'UNKNOWN';
+        $html_detected_by = '';
+
+        if ( strpos( $buffer, 'Performance optimized by WP Rocket' ) !== false ) {
+            $html_detected_by = 'WP Rocket HTML';
+            $html_status_text = (strpos( $buffer, 'cached@' ) !== false) ? 'HIT' : 'MISS_OR_BYPASS_HTML';
+        } elseif ( preg_match( '/<!--\s*Performance optimized by W3 Total Cache.*?Page Caching(?:\s+using\s+.*?)?:\s*(.*?)(\s*<|\s*Content Delivery Network|\s*Minify|\s*Database Caching|\s*Object Caching|$)/is', $buffer, $w3tc_matches ) ) {
+            $w3tc_status_val = strtolower(trim($w3tc_matches[1]));
+            $html_detected_by = 'W3TC HTML Debug';
+            if ( $w3tc_status_val === 'enhanced' || $w3tc_status_val === 'basic' || strpos($w3tc_status_val, 'hit') !== false ) $html_status_text = 'HIT';
+            elseif ( strpos($w3tc_status_val, 'miss') !== false ) $html_status_text = 'MISS';
+            elseif ( strpos($w3tc_status_val, 'not appicable') !== false || strpos($w3tc_status_val, 'disabled') !== false ) $html_status_text = 'BYPASS';
+            else $html_status_text = 'INFO: ' . esc_html(ucfirst($w3tc_status_val));
+        }
+
+        if ($html_status_text !== 'UNKNOWN') {
+            $header_status_part = explode(' by ', $this->main_request_cache_status)[0];
+            $header_by_part = isset(explode(' by ', $this->main_request_cache_status)[1]) ? explode(' by ', $this->main_request_cache_status)[1] : '';
+            $is_header_definitive_cdn_or_server_hit = ($header_status_part === 'HIT' && (stripos($header_by_part, 'Cloudflare') !== false || stripos($header_by_part, 'LiteSpeed') !== false || stripos($header_by_part, 'SG Optimizer') !== false || stripos($header_by_part, 'Varnish') !== false));
+
+            $updated_status = false;
+            if ($html_status_text === 'HIT') {
+                if ($is_header_definitive_cdn_or_server_hit && stripos($header_by_part, $html_detected_by) === false) {
+                    $this->main_request_cache_status .= '; ' . $html_status_text . ' (HTML: ' . $html_detected_by . ')';
+                } else {
+                    $this->main_request_cache_status = $html_status_text . ' by ' . $html_detected_by;
+                }
+                $updated_status = true;
+            } elseif (in_array($html_status_text, ['MISS', 'MISS_OR_BYPASS_HTML', 'BYPASS'])) {
+                if (in_array($header_status_part, ['UNKNOWN', 'MISS', 'POTENTIALLY BROWSER CACHED', 'INFO (Handled)']) || stripos($header_by_part, $html_detected_by) !== false) {
+                    $this->main_request_cache_status = $html_status_text . ' by ' . $html_detected_by;
+                    $updated_status = true;
+                }
+            } elseif (strpos($html_status_text, 'INFO:') === 0 && $header_status_part === 'UNKNOWN') {
+                $this->main_request_cache_status = $html_status_text . ' by ' . $html_detected_by;
+                $updated_status = true;
+            }
+            if ($updated_status && defined('WP_DEBUG') && WP_DEBUG) {
+                 error_log('[Cache Detector] HTML Footprint. Original header status: ' . $header_status_part . ' by ' . $header_by_part . '. HTML found: ' . $html_status_text . ' by ' . $html_detected_by . '. Final combined status: ' . $this->main_request_cache_status);
+            }
+        }
+        return $buffer;
+    }
+
+    public function inspect_main_request_headers() {
+        if ( is_admin() || wp_doing_ajax() || headers_sent() ) return;
+        $this->main_request_headers = headers_list();
+        $this->main_request_cache_status = $this->analyze_headers( $this->main_request_headers );
+        if ( defined('WP_DEBUG') && WP_DEBUG ) {
+            error_log('[Cache Detector] Headers Inspected. Status: ' . $this->main_request_cache_status . '. Headers: ' . print_r($this->main_request_headers, true));
+        }
+    }
+
+    private function analyze_headers( $headers ) {
+        $status_candidates = [];
+        if (is_array($headers)) {
+            foreach ( $headers as $header_line ) {
+                $header_parts = explode(':', $header_line, 2);
+                if (count($header_parts) < 2) continue;
+                $name = strtolower(trim($header_parts[0]));
+                $value = trim($header_parts[1]);
+                $value_lower = strtolower($value);
+
+                if ( $name === 'cf-cache-status' ) $status_candidates[] = ['status' => strtoupper($value_lower), 'by' => 'Cloudflare', 'priority' => 1];
+                elseif ( $name === 'x-litespeed-cache' ) {
+                    $ls_status = 'UNKNOWN';
+                    if (strpos($value_lower, 'hit') !== false) $ls_status = 'HIT';
+                    elseif (strpos($value_lower, 'miss') !== false) $ls_status = 'MISS';
+                    else $ls_status = strtoupper($value_lower);
+                    $status_candidates[] = ['status' => $ls_status, 'by' => 'LiteSpeed', 'priority' => 2];
+                }
+                elseif ( $name === 'x-sg-cache' ) $status_candidates[] = ['status' => (($value_lower === 'hit') ? 'HIT' : strtoupper($value_lower)), 'by' => 'SG Optimizer', 'priority' => 2];
+                elseif ( $name === 'x-varnish-cache' ) $status_candidates[] = ['status' => (strpos($value_lower, 'hit') !== false ? 'HIT' : (strpos($value_lower, 'miss') !== false ? 'MISS' : strtoupper($value_lower))), 'by' => 'Varnish (X-Varnish-Cache)', 'priority' => 2];
+                elseif ( $name === 'x-wp-rocket-cache' ) $status_candidates[] = ['status' => strtoupper($value_lower), 'by' => 'WP Rocket Header', 'priority' => 3];
+                elseif ( $name === 'x-cache' ) { // Generic X-Cache, could be Varnish or other
+                    $xc_status = 'UNKNOWN';
+                    if (strpos($value_lower, 'hit') !== false) $xc_status = 'HIT';
+                    elseif (strpos($value_lower, 'miss') !== false) $xc_status = 'MISS';
+                    else $xc_status = strtoupper($value_lower);
+                    $status_candidates[] = ['status' => $xc_status, 'by' => 'Proxy (X-Cache)', 'priority' => 3];
+                }
+                elseif ( $name === 'x-varnish' ) $status_candidates[] = ['status' => 'INFO_HANDLED', 'by' => 'Varnish ID', 'priority' => 4];
+                elseif ( $name === 'age' && is_numeric($value) && intval($value) > 0 ) $status_candidates[] = ['status' => 'HIT_AGE', 'by' => 'Proxy/CDN (Age Header)', 'priority' => 4];
+                elseif ( $name === 'x-sucuri-cache' ) $status_candidates[] = ['status' => strtoupper($value_lower), 'by' => 'Sucuri FW', 'priority' => 1];
+                 // Add more known headers here, e.g. Fastly, Akamai etc.
+                 // Fastly: x-served-by, x-cache (HIT, MISS), x-cache-hits
+                 // Akamai: x-check-cacheable, x-cache (TCP_HIT, TCP_MISS, etc)
+            }
+        }
+
+        $final_status = 'UNKNOWN'; $final_by = '';
+        if (!empty($status_candidates)) {
+            usort($status_candidates, function($a, $b) { return $a['priority'] - $b['priority']; });
+            $chosen_candidate = null;
+            foreach ($status_candidates as $candidate) { // Prefer HITs first
+                if ($candidate['status'] === 'HIT' || $candidate['status'] === 'HIT_AGE') { $chosen_candidate = $candidate; break; }
+            }
+            if (!$chosen_candidate) { // If no HIT, take the highest priority non-UNKNOWN, non-INFO
+                foreach ($status_candidates as $candidate) {
+                    if ($candidate['status'] !== 'INFO_HANDLED' && $candidate['status'] !== 'UNKNOWN') { $chosen_candidate = $candidate; break; }
+                }
+            }
+            if (!$chosen_candidate && !empty($status_candidates) && $status_candidates[0]['status'] === 'INFO_HANDLED') { // Fallback to INFO
+                $chosen_candidate = $status_candidates[0];
+            }
+             if (!$chosen_candidate && !empty($status_candidates)) { // Fallback to first if all else fails
+                $chosen_candidate = $status_candidates[0];
+            }
+
+            if ($chosen_candidate) {
+                $final_status = $chosen_candidate['status'];
+                $final_by = $chosen_candidate['by'];
+                if ($final_status === 'HIT_AGE') $final_status = 'HIT';
+                if ($final_status === 'INFO_HANDLED') $final_status = 'INFO (Handled)';
+            }
+        }
+
+        if ( in_array($final_status, ['UNKNOWN', 'MISS', 'INFO (Handled)']) ) {
+            $cache_control = ''; $expires = ''; $pragma = '';
+            if(is_array($headers)) {
+                foreach($headers as $header_line) {
+                    $header_parts = explode(':', $header_line, 2);
+                    if (count($header_parts) < 2) continue;
+                    $name = strtolower(trim($header_parts[0]));
+                    $value_l = strtolower(trim($header_parts[1]));
+                    if ($name === 'cache-control') $cache_control = $value_l;
+                    if ($name === 'expires') $expires = $value_l;
+                    if ($name === 'pragma') $pragma = $value_l;
+                }
+            }
+            if (strpos($cache_control, 'no-cache') !== false || strpos($cache_control, 'no-store') !== false || strpos($pragma, 'no-cache') !== false) {
+                $final_status = 'UNCACHED'; $final_by = ($final_by ? $final_by . ', ' : '') . 'Browser Directives';
+            } elseif (strpos($cache_control, 'max-age=0') !== false && $final_status === 'MISS') {
+                $final_status = 'UNCACHED'; $final_by = ($final_by ? $final_by . ', ' : '') . 'Browser Directives';
+            } elseif ($final_status === 'UNKNOWN' && (!empty($cache_control) || !empty($expires))) {
+                if (strpos($cache_control, 'public') !== false || (strpos($cache_control, 'private') !== false && strpos($cache_control, 'max-age=0') === false ) ) {
+                     $final_status = 'POTENTIALLY BROWSER CACHED'; $final_by = 'Browser Headers';
+                }
+            }
+        }
+        return $final_status . ($final_by ? " by " . $final_by : "");
+    }
+
+    public function get_main_request_cache_status() {
+        return $this->main_request_cache_status;
+    }
+
+    public function get_main_request_headers() {
+        return $this->main_request_headers;
+    }
+
+    public function activate() {
+        if ( defined('WP_DEBUG') && WP_DEBUG ) error_log('[Cache Detector] Plugin activated.');
+    }
+
+    public function deactivate() {
+        if ( defined('WP_DEBUG') && WP_DEBUG ) error_log('[Cache Detector] Plugin deactivated.');
+    }
+}
+
+Cache_Detector::get_instance();

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,96 @@
+=== Cache Detector ===
+Contributors: Jules AI Assistant
+Tags: cache, performance, debug, http headers, cache status
+Requires at least: 5.0
+Tested up to: 6.5
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Detects and displays cache status for loaded URLs in WordPress. Helps in debugging cache configurations.
+
+== Description ==
+
+Cache Detector is a WordPress plugin designed to help site administrators and developers understand how their website's pages and assets are being cached. It inspects HTTP headers and other indicators from various caching layers (server cache, CDN, plugin caches, browser cache) and displays the status for each loaded resource.
+
+This tool aims to make it easier to diagnose cache HIT/MISS issues, understand cache behavior with query strings (like UTM parameters), and verify that caching configurations are working as expected across different caching mechanisms.
+
+Current version focuses on detecting main page cache status and preparing for asset status detection.
+
+== Installation ==
+
+1. Upload the `cache-detector` folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. (Future steps will include viewing cache status in the admin bar or a dedicated debug panel).
+
+== Frequently Asked Questions ==
+
+= How does it detect cache status? =
+
+The plugin inspects HTTP response headers for the main page and uses the browser's Performance API to analyze loaded assets (CSS, JS, images).
+It looks for specific headers from CDNs (like Cloudflare's `CF-Cache-Status`), server-level caches (e.g., LiteSpeed's `X-LiteSpeed-Cache`, SiteGround's `X-SG-Cache`, Varnish's `X-Cache`), and WordPress caching plugins (e.g., `X-WP-Rocket-Cache`).
+It also checks for HTML comments left by plugins like WP Rocket or W3 Total Cache (in debug mode).
+For assets, cache status is inferred from `transferSize`, `decodedBodySize`, and `serverTiming` entries in the Performance API, as direct header inspection for cross-origin assets is limited by CORS.
+
+= How do I see the cache status? =
+
+If you are a logged-in administrator, the plugin adds an item to the WordPress Admin Bar.
+It will display the main page's cache status (e.g., "Cache: HIT by Cloudflare").
+Hovering over this item will reveal a dropdown:
+*   "View Raw Page Headers": Shows the HTTP response headers collected for the main page.
+*   A list of loaded assets (CSS, JS, images) from the current page, each with its inferred cache status (e.g., HIT, MISS, DOWNLOADED). Clicking an asset shows more details.
+    *Note*: Asset data is sent from your browser to the server via AJAX and stored temporarily. It might take one page refresh after the initial visit for the full asset list to populate in the admin bar for a specific page.
+
+= What do the statuses mean? =
+
+*   **HIT**: The resource was successfully served from a cache (CDN, server, plugin, or browser).
+*   **MISS**: The resource was not found in the checked cache(s) and was likely served directly from the origin server or a lower cache layer.
+*   **BYPASS**: A cache was intentionally skipped for this resource.
+*   **DYNAMIC**: Typically from CDNs like Cloudflare, meaning the resource is not eligible for caching by default (often HTML pages) and was served from the origin.
+*   **UNCACHED**: The resource is explicitly configured not to be cached by browser directives.
+*   **POTENTIALLY BROWSER CACHED**: Server/CDN cache was a MISS or UNKNOWN, but browser caching headers are present.
+*   **INFO (Handled)**: A caching layer (like Varnish) processed the request, but a specific HIT/MISS status wasn't determined from its headers alone.
+*   **UNKNOWN**: The plugin could not determine the cache status from available headers or footprints.
+The "by [Source]" part indicates which system or header was primarily used for the determination (e.g., "by Cloudflare", "by LiteSpeed", "by WP Rocket HTML").
+
+= Will this plugin slow down my site? =
+
+The plugin is designed to be lightweight. For regular site visitors, it adds no frontend processing.
+For logged-in administrators, it collects headers on the server-side and uses the browser's Performance API on the client-side. These operations are generally efficient. The display is limited to the admin bar.
+
+== Screenshots ==
+
+1. Cache Detector in Admin Bar - Main Page HIT
+2. Cache Detector Admin Bar - Dropdown with Asset List
+3. Cache Detector - Asset Detail Alert
+
+(Screenshots will be added once the plugin is visually testable in a WordPress environment)
+
+== Changelog ==
+
+= 0.1.0 - 2024-07-12 =
+* Initial public release.
+* Detects main page cache status via HTTP headers and HTML comments.
+* Detects asset cache status (CSS, JS, images) using Performance API (transferSize, serverTiming) and AJAX.
+* Displays main page and asset cache statuses in the WordPress Admin Bar for logged-in administrators.
+* Color-coded statuses for quick visual identification.
+* Handles known headers from Cloudflare, LiteSpeed, WP Rocket, W3 Total Cache (debug), SiteGround Optimizer, Varnish, and generic browser caching.
+* Prioritized logic for interpreting multiple caching layers.
+
+== Upgrade Notice ==
+
+= 0.1.0 =
+Initial version. Please report any issues or suggestions.
+
+== Development ==
+
+This plugin aims to be a comprehensive tool for WordPress cache diagnostics. Contributions and feedback are welcome.
+GitHub: (Link to be added if publicly hosted)
+
+Future considerations:
+* More refined UI/UX, potentially a dedicated panel instead of just admin bar popups.
+* Deeper integration for specific plugin APIs if available and useful.
+* Visual cues on the frontend itself (optional overlay for admins).
+* History or logging of cache statuses for pages.
+* Support for detecting REST API endpoint caching.
+* More robust handling of Service Worker caches for assets.


### PR DESCRIPTION
Implements a WordPress plugin to detect and display cache status for the main page and loaded assets.

Features:
- Detects main page cache status by inspecting HTTP response headers (Cloudflare, LiteSpeed, SG Optimizer, Varnish, WP Rocket, W3TC, etc.) and HTML footprints (WP Rocket, W3TC debug).
- Uses a priority-based logic to interpret headers from multiple caching layers.
- Infers asset (CSS, JS, images) cache status using the Performance API (transferSize, decodedBodySize, serverTiming) on the client-side.
- Asset data is sent via AJAX to the backend and stored in a transient.
- Displays main page and asset cache statuses in the WordPress Admin Bar for logged-in administrators.
- Statuses are color-coded for quick visual identification.
- Provides an option to view raw HTTP headers for the main page.
- Includes a comprehensive readme.txt.